### PR TITLE
Convert stdin instead of returning usage.

### DIFF
--- a/cmd/beni/main.go
+++ b/cmd/beni/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -67,15 +68,45 @@ func run(filenames []string, o CLOptions) error {
 	return nil
 }
 
+func convertStdIn(o CLOptions) {
+	lexer := o.Lexer
+	theme := o.Theme
+	format := o.Formatter
+
+	if lexer == "" {
+		lexer = "Go"
+	}
+
+	if theme == "" {
+		theme = "base16"
+	}
+
+	if format == "" {
+		format = "Terminal256"
+	}
+
+	stdin := bufio.NewReader(os.Stdin)
+	stdout := bufio.NewWriter(os.Stdout)
+	defer stdout.Flush()
+
+	beni.Highlight(stdin, stdout, lexer, theme, format)
+	return
+}
+
 func main() {
 	flag.BoolVar(&options.Help, "h", false, "show help message")
 	flag.StringVar(&options.Lexer, "l", "", "force lexer")
 	flag.StringVar(&options.Formatter, "f", "Terminal256", "choose formatter")
-	flag.StringVar(&options.Theme, "t", "base16", "choose formatter")
+	flag.StringVar(&options.Theme, "t", "base16", "choose theme")
 	flag.Parse()
 
-	if options.Help || flag.NArg() == 0 {
+	if options.Help {
 		usage()
+		return
+	}
+
+	if flag.NArg() == 0 {
+		convertStdIn(options)
 		return
 	}
 


### PR DESCRIPTION
This change makes it so that beni will work on STDIN when no arguments
are passed.  Also, some defaults are set if no parameters are passed
either.

---

I just stumbled onto this project this weekend while working on
GopherGala.  I was planning to work on something similar when I was
alerted to your repo.  My original idea was to have the application work
on the STDIN sort of like `cat`, `sed`, `less` etc. do.

Anyway, I went ahead and created a stub version of the app using your
exported beni.Highlight function just to have something to enter. But
I planned to go ahead and do a PR to add this functionality to your app.
So here it is.

Cheers,

David
